### PR TITLE
Add refresh_materialized_view

### DIFF
--- a/lib/scenic/adapters/oracle.rb
+++ b/lib/scenic/adapters/oracle.rb
@@ -39,6 +39,15 @@ module Scenic
         execute("drop materialized view #{quote_table_name(name)}")
       end
 
+      def refresh_materialized_view(name)
+        plsql = <<~EOS
+          begin
+            dbms_mview.refresh('#{name}');
+          end;
+        EOS
+        execute(plsql)
+      end
+
       delegate :connection, to: :@connectable
       delegate :select_all, :execute, :quote_table_name, to: :connection
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,12 @@ def drop_all_mviews
   end
 end
 
+def drop_all_tables
+  ActiveRecord::Base.connection.select_values("select table_name from user_tables").each do |table|
+    ActiveRecord::Base.connection.execute("drop table #{table}")
+  end
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"


### PR DESCRIPTION
This adds the refresh_materialized_view method to align with `Scenic::Adapters::Postgres.refresh_materialized_view`.

This is currently a naive refresh—concurrency/atomic refreshes are not yet supported.