### PR TITLE
Concurrent mview refresh

### DIFF
--- a/lib/scenic/adapters/oracle.rb
+++ b/lib/scenic/adapters/oracle.rb
@@ -39,10 +39,11 @@ module Scenic
         execute("drop materialized view #{quote_table_name(name)}")
       end
 
-      def refresh_materialized_view(name)
+      def refresh_materialized_view(name, concurrently: false)
+        atomic_refresh = concurrently.to_s.upcase
         plsql = <<~EOS
           begin
-            dbms_mview.refresh('#{name}');
+            dbms_mview.refresh('#{name}', method => '?', atomic_refresh => #{atomic_refresh});
           end;
         EOS
         execute(plsql)

--- a/lib/scenic/adapters/oracle.rb
+++ b/lib/scenic/adapters/oracle.rb
@@ -39,6 +39,15 @@ module Scenic
         execute("drop materialized view #{quote_table_name(name)}")
       end
 
+      def refresh_materialized_view(name)
+        plsql = <<~EOS
+          begin
+            dbms_mview.refresh('#{name}');
+          end;
+        EOS
+        execute(plsql)
+      end
+
       delegate :connection, to: :@connectable
       delegate :select_all, :execute, :quote_table_name, to: :connection
 

--- a/spec/scenic/oracle_adapter_spec.rb
+++ b/spec/scenic/oracle_adapter_spec.rb
@@ -1,91 +1,133 @@
 RSpec.describe Scenic::OracleAdapter do
-  let(:adapter) { Scenic::Adapters::Oracle.new }
+  context "integration" do
+    let(:adapter) { Scenic::Adapters::Oracle.new }
 
-  after do
-    drop_all_views
-    drop_all_mviews
-    drop_all_tables
+    after do
+      drop_all_views
+      drop_all_mviews
+      drop_all_tables
+    end
+
+    it "has a version number" do
+      expect(Scenic::OracleAdapter::VERSION).not_to be nil
+    end
+
+    it ".views" do
+      adapter.create_view("one", "select 1 as a from dual")
+      adapter.create_view("two", "select 2 as a from dual")
+      expect(adapter.views.size).to eq(2)
+      one = adapter.views.find { |view| view.name == "one" }
+      expect(one.name).to eq("one")
+      expect(one.definition.downcase).to eq("select 1 as a from dual")
+    end
+
+    it ".create_view" do
+      adapter.create_view("blah", "select 1 as a from dual")
+      expect(view_exists?("blah")).to be true
+    end
+
+    it ".drop_view" do
+      adapter.create_view("blah", "select 1 as a from dual")
+      expect(view_exists?("blah")).to be true
+      adapter.drop_view("blah")
+      expect(view_exists?("blah")).to be false
+    end
+
+    it "replaces a view that doesn't exist" do
+      expect(view_exists?("blah")).to be false
+      adapter.replace_view("blah", "select 1 as a from dual")
+      expect(view_exists?("blah")).to be true
+    end
+
+    it "replaces a view that does exist" do
+      adapter.create_view("blah", "select 1 as a from dual")
+      expect(view_exists?("blah")).to be true
+      adapter.replace_view("blah", "select 2 as a from dual")
+      expect(find_view("blah").definition).to eq("select 2 as a from dual")
+    end
+
+    it "updates a view" do
+      adapter.create_view("blah", "select 1 as a from dual")
+      expect(view_exists?("blah")).to be true
+      adapter.update_view("blah", "select 1 as a, 2 as b from dual")
+      expect(find_view("blah").definition).to eq("select 1 as a, 2 as b from dual")
+    end
+
+    it "creates a materialized view" do
+      adapter.create_materialized_view("blah", "select 1 as a from dual")
+      view = find_mview("blah")
+      expect(view.materialized).to be true
+      expect(view.definition).to eq("select 1 as a from dual")
+    end
+
+    it "drops a materialized view" do
+      adapter.create_materialized_view("blah", "select 1 as a from dual")
+      expect(find_mview("blah").materialized).to be true
+      adapter.drop_materialized_view("blah")
+      expect(mview_exists?("blah")).to be false
+    end
+
+    it "updates a materialized view" do
+      adapter.create_materialized_view("blah", "select 1 as a from dual")
+      view = find_mview("blah")
+      expect(view.materialized).to be true
+      expect(view.definition).to eq("select 1 as a from dual")
+      adapter.update_materialized_view("blah", "select 1 as a, 2 as b from dual")
+      view = find_mview("blah")
+      expect(view.materialized).to be true
+      expect(view.definition).to eq("select 1 as a, 2 as b from dual")
+    end
+
+    context ".refresh_materialized_view" do
+      before do
+        adapter.execute("create table things (id integer, name varchar(50), private char(1))")
+        adapter.execute("insert into things values (1, 'these', 'Y')")
+        adapter.execute("insert into things values (2, 'are', 'N')")
+        adapter.execute("insert into things values (3, 'things', 'Y')")
+        adapter.create_materialized_view("private_things", "select id, name, private from things where private = 'Y'")
+        expect(adapter.connection.select_value("select count(*) from private_things")).to eq(2)
+        adapter.execute("insert into things values (4, 'another', 'Y')")
+      end
+
+      it "refreshes a materialized view" do
+        adapter.refresh_materialized_view("private_things")
+        expect(adapter.connection.select_value("select count(*) from private_things")).to eq(3)
+      end
+
+      it "refreshes a materialized view concurrently" do
+        adapter.refresh_materialized_view("private_things", concurrently: true)
+        expect(adapter.connection.select_value("select count(*) from private_things")).to eq(3)
+      end
+    end
   end
 
-  it "has a version number" do
-    expect(Scenic::OracleAdapter::VERSION).not_to be nil
-  end
+  context "mocks" do
+    it "refreshes a materialized view" do
+      connectable = ActiveRecord::Base
+      a = Scenic::Adapters::Oracle.new(connectable)
+      expected = <<~EOS
+        begin
+          dbms_mview.refresh('private_things', method => '?', atomic_refresh => FALSE);
+        end;
+      EOS
 
-  it ".views" do
-    adapter.create_view("one", "select 1 as a from dual")
-    adapter.create_view("two", "select 2 as a from dual")
-    expect(adapter.views.size).to eq(2)
-    one = adapter.views.find { |view| view.name == "one" }
-    expect(one.name).to eq("one")
-    expect(one.definition.downcase).to eq("select 1 as a from dual")
-  end
+      expect(connectable.connection).to receive(:execute).with(expected)
 
-  it ".create_view" do
-    adapter.create_view("blah", "select 1 as a from dual")
-    expect(view_exists?("blah")).to be true
-  end
+      a.refresh_materialized_view("private_things", concurrently: false)
+    end
 
-  it ".drop_view" do
-    adapter.create_view("blah", "select 1 as a from dual")
-    expect(view_exists?("blah")).to be true
-    adapter.drop_view("blah")
-    expect(view_exists?("blah")).to be false
-  end
+    it "concurrently refreshes a materialized view" do
+      connectable = ActiveRecord::Base
+      a = Scenic::Adapters::Oracle.new(connectable)
+      expected = <<~EOS
+        begin
+          dbms_mview.refresh('private_things', method => '?', atomic_refresh => TRUE);
+        end;
+      EOS
 
-  it "replaces a view that doesn't exist" do
-    expect(view_exists?("blah")).to be false
-    adapter.replace_view("blah", "select 1 as a from dual")
-    expect(view_exists?("blah")).to be true
-  end
+      expect(connectable.connection).to receive(:execute).with(expected)
 
-  it "replaces a view that does exist" do
-    adapter.create_view("blah", "select 1 as a from dual")
-    expect(view_exists?("blah")).to be true
-    adapter.replace_view("blah", "select 2 as a from dual")
-    expect(find_view("blah").definition).to eq("select 2 as a from dual")
-  end
-
-  it "updates a view" do
-    adapter.create_view("blah", "select 1 as a from dual")
-    expect(view_exists?("blah")).to be true
-    adapter.update_view("blah", "select 1 as a, 2 as b from dual")
-    expect(find_view("blah").definition).to eq("select 1 as a, 2 as b from dual")
-  end
-
-  it "creates a materialized view" do
-    adapter.create_materialized_view("blah", "select 1 as a from dual")
-    view = find_mview("blah")
-    expect(view.materialized).to be true
-    expect(view.definition).to eq("select 1 as a from dual")
-  end
-
-  it "drops a materialized view" do
-    adapter.create_materialized_view("blah", "select 1 as a from dual")
-    expect(find_mview("blah").materialized).to be true
-    adapter.drop_materialized_view("blah")
-    expect(mview_exists?("blah")).to be false
-  end
-
-  it "updates a materialized view" do
-    adapter.create_materialized_view("blah", "select 1 as a from dual")
-    view = find_mview("blah")
-    expect(view.materialized).to be true
-    expect(view.definition).to eq("select 1 as a from dual")
-    adapter.update_materialized_view("blah", "select 1 as a, 2 as b from dual")
-    view = find_mview("blah")
-    expect(view.materialized).to be true
-    expect(view.definition).to eq("select 1 as a, 2 as b from dual")
-  end
-
-  it "refreshes a materialized view" do
-    adapter.execute("create table things (id integer, name varchar(50), private char(1))")
-    adapter.execute("insert into things values (1, 'these', 'Y')")
-    adapter.execute("insert into things values (2, 'are', 'N')")
-    adapter.execute("insert into things values (3, 'things', 'Y')")
-    adapter.create_materialized_view("private_things", "select id, name, private from things where private = 'Y'")
-    expect(adapter.connection.select_value("select count(*) from private_things")).to eq(2)
-    adapter.execute("insert into things values (4, 'another', 'Y')")
-    adapter.refresh_materialized_view("private_things")
-    expect(adapter.connection.select_value("select count(*) from private_things")).to eq(3)
+      a.refresh_materialized_view("private_things", concurrently: true)
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,12 @@ def drop_all_mviews
   end
 end
 
+def drop_all_tables
+  ActiveRecord::Base.connection.select_values("select table_name from user_tables").each do |table|
+    ActiveRecord::Base.connection.execute("drop table #{table}")
+  end
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"


### PR DESCRIPTION
This adds support for concurrently refreshing materialized view.

This also re-organizes the specs to separate out specs that actually hit the database and those that just use mocks. This was done because the spec teardown was getting caught in the mock assertions and causing them to fail.