### PR TITLE
Reapply materialized view indexes

### DIFF
--- a/lib/scenic/adapters/oracle.rb
+++ b/lib/scenic/adapters/oracle.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative "oracle/index_reapplication"
+require_relative "oracle/indexes"
+
 module Scenic
   module Adapters
     class Oracle
@@ -33,8 +36,10 @@ module Scenic
       end
 
       def update_materialized_view(name, definition)
-        drop_materialized_view(name)
-        create_materialized_view(name, definition)
+        IndexReapplication.new(connection: connection).on(name) do
+          drop_materialized_view(name)
+          create_materialized_view(name, definition)
+        end
       end
 
       def drop_materialized_view(name)

--- a/lib/scenic/adapters/oracle/index.rb
+++ b/lib/scenic/adapters/oracle/index.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Scenic
+  module Adapters
+    class Oracle
+      class Index < Scenic::Index
+        attr_reader :columns
+
+        def initialize(object_name:, index_name:, columns:, definition:)
+          @object_name = object_name
+          @index_name = index_name
+          @columns = columns
+          @definition = definition
+        end
+      end
+    end
+  end
+end

--- a/lib/scenic/adapters/oracle/index_reapplication.rb
+++ b/lib/scenic/adapters/oracle/index_reapplication.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Scenic
+  module Adapters
+    class Oracle
+      class IndexReapplication
+        def initialize(connection:, speaker: ActiveRecord::Migration)
+          @connection = connection
+          @speaker = speaker
+        end
+
+        def on(name)
+          indexes = Indexes.new(connection: connection).on(name)
+
+          yield
+
+          indexes.each(&method(:try_index_create))
+        end
+
+        private
+
+        attr_reader :connection, :speaker
+
+        def try_index_create(index)
+          if valid_index?(index)
+            if connection.execute(index.definition)
+              say "index '#{index.index_name}' on '#{index.object_name}' has been recreated"
+            end
+          else
+            say "index '#{index.index_name}' on '#{index.object_name}' is no longer valid and has been dropped."
+          end
+        end
+
+        def valid_index?(index)
+          object_columns = Set.new(object_columns(index.object_name))
+          index_columns = Set.new(index.columns)
+
+          index_columns.subset?(object_columns)
+        end
+
+        def object_columns(name)
+          connection.select_values(<<-EOSQL)
+            select lower(column_name)
+            from user_tab_cols
+            where table_name = '#{name}'
+          EOSQL
+        end
+
+        def say(message)
+          subitem = true
+          speaker.say(message, subitem)
+        end
+      end
+    end
+  end
+end

--- a/lib/scenic/adapters/oracle/indexes.rb
+++ b/lib/scenic/adapters/oracle/indexes.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative "index"
+
+module Scenic
+  module Adapters
+    class Oracle
+      class Indexes
+        def initialize(connection:)
+          @connection = connection
+        end
+
+        def on(name)
+          indexes_on(name).map(&method(:index_from_database))
+        end
+
+        private
+
+        attr_reader :connection
+        delegate :quote_table_name, to: :connection
+
+        def indexes_on(name)
+          connection.select_all(<<-EOSQL)
+            select
+              table_name as object_name,
+              index_name,
+              dbms_metadata.get_ddl('INDEX', index_name, table_owner) as definition
+            from user_indexes
+            where table_name = upper('#{name}')
+          EOSQL
+        end
+
+        def index_columns(index_name)
+          connection.select_values(<<-EOSQL)
+            select lower(column_name)
+            from user_ind_columns
+            where index_name = upper('#{index_name}')
+            order by column_position
+          EOSQL
+        end
+
+        def index_from_database(result)
+          Scenic::Adapters::Oracle::Index.new(
+            object_name: result["object_name"],
+            index_name: result["index_name"],
+            columns: index_columns(result["index_name"]),
+            definition: result["definition"]
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,10 @@ def drop_all_tables
   end
 end
 
+def select_value(sql)
+  ActiveRecord::Base.connection.select_value(sql)
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"


### PR DESCRIPTION
This reapplies any existing indexes that are still valid after a materialized view is updates/redefined.

[Fixes #5]