### PR TITLE
Load OracleEnhancedSchemaDumper if defined

### DIFF
--- a/lib/scenic/adapters/oracle/railtie.rb
+++ b/lib/scenic/adapters/oracle/railtie.rb
@@ -8,7 +8,11 @@ module Scenic
     class Oracle
       class Railtie < Rails::Railtie
         ActiveSupport.on_load(:active_record) do
-          ActiveRecord::ConnectionAdapters::OracleEnhanced::SchemaDumper.prepend Scenic::SchemaDumper
+          if defined?(ActiveRecord::ConnectionAdapters::OracleEnhancedSchemaDumper)
+            ActiveRecord::ConnectionAdapters::OracleEnhancedSchemaDumper.prepend Scenic::SchemaDumper
+          else
+            ActiveRecord::ConnectionAdapters::OracleEnhanced::SchemaDumper.prepend Scenic::SchemaDumper
+          end
         end
       end
     end


### PR DESCRIPTION
Older versions of `activerecord-oracle_enhanced-adapter` don't have `ActiveRecord::ConnectionAdapters::OracleEnhanced::SchemaDumper` module but have a `ActiveRecord::ConnectionAdapters::OracleEnhancedSchemaDumper` instead.