### PR TITLE
Pass no_data keyword arg for update_materialized_view

### DIFF
--- a/lib/scenic/adapters/oracle.rb
+++ b/lib/scenic/adapters/oracle.rb
@@ -36,10 +36,10 @@ module Scenic
         execute("create materialized view #{quote_table_name(name)} #{'build deferred' if no_data} as #{definition}")
       end
 
-      def update_materialized_view(name, definition)
+      def update_materialized_view(name, definition, no_data: false)
         IndexReapplication.new(connection: connection).on(name) do
           drop_materialized_view(name)
-          create_materialized_view(name, definition)
+          create_materialized_view(name, definition, no_data: no_data)
         end
       end
 

--- a/spec/scenic/oracle_adapter_spec.rb
+++ b/spec/scenic/oracle_adapter_spec.rb
@@ -89,6 +89,19 @@ RSpec.describe Scenic::OracleAdapter do
       expect(view.definition).to eq("select 1 as a, 2 as b from dual")
     end
 
+  it "updates an unpopulated materialized view" do
+      adapter.create_materialized_view("blah", "select 1 as a from dual", no_data: true)
+      view = find_mview("blah")
+      expect(view.materialized).to be true
+      expect(view.definition).to eq("select 1 as a from dual")
+      expect(select_value("select count(*) from blah")).to eq(0)
+      adapter.update_materialized_view("blah", "select 1 as a, 2 as b from dual", no_data: true)
+      view = find_mview("blah")
+      expect(view.materialized).to be true
+      expect(view.definition).to eq("select 1 as a, 2 as b from dual")
+      expect(select_value("select count(*) from blah")).to eq(0)
+    end
+
     context "updates a materialized view with indexes" do
       before do
         adapter.create_materialized_view("things", "select 1 as id, 'something' as name from dual")


### PR DESCRIPTION
Scenic expects a 'no_data' keyword arg for update_materialized_view. Accept this arg, and pass it to create_materialized_view.