### PR TITLE
Add `parallel` option for mviews

### DIFF
--- a/lib/scenic/adapters/oracle.rb
+++ b/lib/scenic/adapters/oracle.rb
@@ -32,14 +32,14 @@ module Scenic
         create_view(name, definition)
       end
 
-      def create_materialized_view(name, definition, no_data: false)
-        execute("create materialized view #{quote_table_name(name)} #{'build deferred' if no_data} as #{definition}")
+      def create_materialized_view(name, definition, no_data: false, parallel: false)
+        execute("create materialized view #{quote_table_name(name)} #{'parallel' if parallel} #{'build deferred' if no_data} as #{definition}")
       end
 
-      def update_materialized_view(name, definition, no_data: false)
+      def update_materialized_view(name, definition, no_data: false, parallel: false)
         IndexReapplication.new(connection: connection).on(name) do
           drop_materialized_view(name)
-          create_materialized_view(name, definition, no_data: no_data)
+          create_materialized_view(name, definition, no_data: no_data, parallel: parallel)
         end
       end
 

--- a/spec/scenic/oracle_adapter_spec.rb
+++ b/spec/scenic/oracle_adapter_spec.rb
@@ -233,9 +233,6 @@ RSpec.describe Scenic::OracleAdapter do
         it "adds the parallel flag to the create command" do
           connectable = ActiveRecord::Base
           a = Scenic::Adapters::Oracle.new(connectable)
-          expected = <<~EOS
-            create materialized view "PARALLEL_TEST" parallel as select 1 as id from dual
-          EOS
 
           expect(connectable.connection).to receive(:execute).with(a_string_matching(/\sparallel\s/))
 
@@ -247,11 +244,8 @@ RSpec.describe Scenic::OracleAdapter do
         it "omits the parallel flag in the create command" do
           connectable = ActiveRecord::Base
           a = Scenic::Adapters::Oracle.new(connectable)
-          expected = <<~EOS
-            create materialized view "PARALLEL_TEST" as select 1 as id from dual
-          EOS
 
-          expect(connectable.connection).to receive(:execute).with(expected)
+          expect(connectable.connection).not_to receive(:execute).with(a_string_matching(/\sparallel\s/))
 
           a.create_materialized_view("parallel_test", "select 1 as id from dual", parallel: false)
         end
@@ -259,11 +253,8 @@ RSpec.describe Scenic::OracleAdapter do
         it "defaults to disabling parallel" do
           connectable = ActiveRecord::Base
           a = Scenic::Adapters::Oracle.new(connectable)
-          expected = <<~EOS
-            create materialized view "PARALLEL_TEST" as select 1 as id from dual
-          EOS
 
-          expect(connectable.connection).to receive(:execute).with(expected)
+          expect(connectable.connection).not_to receive(:execute).with(a_string_matching(/\sparallel\s/))
 
           a.create_materialized_view("parallel_test", "select 1 as id from dual")
         end

--- a/spec/scenic/oracle_adapter_spec.rb
+++ b/spec/scenic/oracle_adapter_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe Scenic::OracleAdapter do
           connectable = ActiveRecord::Base
           a = Scenic::Adapters::Oracle.new(connectable)
           expected = <<~EOS
-            create materialized view parallel_test parallel as select 1 as id from dual
+            create materialized view "PARALLEL_TEST" parallel as select 1 as id from dual
           EOS
 
           expect(connectable.connection).to receive(:execute).with(expected)
@@ -248,7 +248,7 @@ RSpec.describe Scenic::OracleAdapter do
           connectable = ActiveRecord::Base
           a = Scenic::Adapters::Oracle.new(connectable)
           expected = <<~EOS
-            create materialized view parallel_test as select 1 as id from dual
+            create materialized view "PARALLEL_TEST" as select 1 as id from dual
           EOS
 
           expect(connectable.connection).to receive(:execute).with(expected)
@@ -260,7 +260,7 @@ RSpec.describe Scenic::OracleAdapter do
           connectable = ActiveRecord::Base
           a = Scenic::Adapters::Oracle.new(connectable)
           expected = <<~EOS
-            create materialized view parallel_test as select 1 as id from dual
+            create materialized view "PARALLEL_TEST" as select 1 as id from dual
           EOS
 
           expect(connectable.connection).to receive(:execute).with(expected)

--- a/spec/scenic/oracle_adapter_spec.rb
+++ b/spec/scenic/oracle_adapter_spec.rb
@@ -228,6 +228,48 @@ RSpec.describe Scenic::OracleAdapter do
   end
 
   context "mocks" do
+    describe "create_materialized_view" do
+      context "with parallel enabled" do
+        it "adds the parallel flag to the create command" do
+          connectable = ActiveRecord::Base
+          a = Scenic::Adapters::Oracle.new(connectable)
+          expected = <<~EOS
+            create materialized view parallel_test parallel as select 1 as id from dual
+          EOS
+
+          expect(connectable.connection).to receive(:execute).with(expected)
+
+          a.create_materialized_view("parallel_test", "select 1 as id from dual", parallel: true)
+        end
+      end
+
+      context "without parallel enabled" do
+        it "omits the parallel flag in the create command" do
+          connectable = ActiveRecord::Base
+          a = Scenic::Adapters::Oracle.new(connectable)
+          expected = <<~EOS
+            create materialized view parallel_test as select 1 as id from dual
+          EOS
+
+          expect(connectable.connection).to receive(:execute).with(expected)
+
+          a.create_materialized_view("parallel_test", "select 1 as id from dual", parallel: false)
+        end
+
+        it "defaults to disabling parallel" do
+          connectable = ActiveRecord::Base
+          a = Scenic::Adapters::Oracle.new(connectable)
+          expected = <<~EOS
+            create materialized view parallel_test as select 1 as id from dual
+          EOS
+
+          expect(connectable.connection).to receive(:execute).with(expected)
+
+          a.create_materialized_view("parallel_test", "select 1 as id from dual")
+        end
+      end
+    end
+
     it "refreshes a materialized view" do
       connectable = ActiveRecord::Base
       a = Scenic::Adapters::Oracle.new(connectable)

--- a/spec/scenic/oracle_adapter_spec.rb
+++ b/spec/scenic/oracle_adapter_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe Scenic::OracleAdapter do
             create materialized view "PARALLEL_TEST" parallel as select 1 as id from dual
           EOS
 
-          expect(connectable.connection).to receive(:execute).with(expected)
+          expect(connectable.connection).to receive(:execute).with(a_string_matching(/\sparallel\s/))
 
           a.create_materialized_view("parallel_test", "select 1 as id from dual", parallel: true)
         end


### PR DESCRIPTION
Adding a custom configuration option for Oracle materialized views, `parallel`. When set like this

```
create_view(:mview_name, materialized: {parallel: true})
```

Then the mview will be created with

`CREATE MATERIALIZED VIEW mview_name PARALLEL...`

What is `parallel`?

From Oracle Docs

> The parallel_clause lets you parallelize creation of the table and set the default degree of parallelism for queries and the DML INSERT, UPDATE, DELETE, and MERGE after table creation.
...
> Specify PARALLEL if you want Oracle to select a degree of parallelism equal to the number of CPUs available on all participating instances times the value of the PARALLEL_THREADS_PER_CPU initialization parameter.

In my testing this setting has led to faster mview refresh times. But I wasn't sure about the impact of using it. So I asked Andy Wattenhofer, an expert on Oracle. (emphasis mine)

---

Me: Is there a reason I wouldn't want to always use it?

Andy: It's not a simple answer, but **you would probably always want to use the parallel clause for large datasets**. It could cause problems if everyone were to use it at the same time. You're effectively creating several server threads to perform the data load in parallel chunks. It would be possible to saturate one or more of the database servers if it were used too heavily. For that reason I would suggest that you try specifying an integer with it, such as parallel 8 or parallel 16 and fine tune it from there to find the value that maximizes on time for the smallest number of threads...I would request that you be careful in your use of too much parallelism.

---

In this version I'm not providing the integer paramater (i.e., `parallel` 8), instead just using `parallel`. This will always use the max number of CPUS. See the above Oracle doc excerpt.

The suggestion is that this should only be used on large, slow materialized views.