### PR TITLE
Refine `view_dependencies` query to return user-conrolled objects

### DIFF
--- a/lib/scenic/adapters/oracle.rb
+++ b/lib/scenic/adapters/oracle.rb
@@ -76,6 +76,8 @@ module Scenic
           from user_objects uo
             left join user_dependencies ud on uo.object_name = ud.name
               and ud.referenced_type in ('VIEW', 'MATERIALIZED VIEW')
+              and ud.referenced_name in (select object_name from user_objects)
+              and ud.referenced_owner = user
           where uo.object_type in ('VIEW', 'MATERIALIZED VIEW')
         EOSQL
       end


### PR DESCRIPTION
Closes #18

As mentioned in https://github.com/cdinger/scenic-oracle_adapter/issues/18#issuecomment-2206657472 this updates the query so that it only returns a dependency if it exists in `user_objects`. So dependencies such as `user_scheduler_jobs` or other Oracle-controlled objects are excluded.