### PR TITLE
Provide fallback view sorting

### DIFF
--- a/lib/scenic/adapters/oracle.rb
+++ b/lib/scenic/adapters/oracle.rb
@@ -17,7 +17,7 @@ module Scenic
       end
 
       def create_view(name, definition)
-        execute("create view #{quote_table_name(name)} as #{definition}")
+        execute("create view #{quote_table_name(name)} as #{trimmed_definition(definition)}")
       end
 
       def drop_view(name)
@@ -25,7 +25,7 @@ module Scenic
       end
 
       def replace_view(name, definition)
-        execute("create or replace view #{quote_table_name(name)} as #{definition}")
+        execute("create or replace view #{quote_table_name(name)} as #{trimmed_definition(definition)}")
       end
 
       def update_view(name, definition)
@@ -34,7 +34,7 @@ module Scenic
       end
 
       def create_materialized_view(name, definition, no_data: false)
-        execute("create materialized view #{quote_table_name(name)} #{'build deferred' if no_data} as #{definition}")
+        execute("create materialized view #{quote_table_name(name)} #{'build deferred' if no_data} as #{trimmed_definition(definition)}")
       end
 
       def update_materialized_view(name, definition, no_data: false)
@@ -135,6 +135,10 @@ module Scenic
 
       def refresh_dependencies_for(name)
         Scenic::Adapters::Oracle::RefreshDependencies.call(name, self, connection)
+      end
+
+      def trimmed_definition(sql)
+        sql.strip.sub(/;$/, "").strip
       end
     end
   end

--- a/lib/scenic/adapters/oracle.rb
+++ b/lib/scenic/adapters/oracle.rb
@@ -69,7 +69,7 @@ module Scenic
       private
 
       def view_dependencies
-        select_all(<<~EOSQL)
+        @view_dependencies ||= select_all(<<~EOSQL)
           select lower(uo.object_name) as name, lower(ud.referenced_name) as dependency
           from user_objects uo
             left join user_dependencies ud on

--- a/lib/scenic/adapters/oracle.rb
+++ b/lib/scenic/adapters/oracle.rb
@@ -14,7 +14,7 @@ module Scenic
 
       def views
         all_view_objects.sort_by do |view_object|
-          dependency_order.index(view_object.name)
+          dependency_order.index(view_object.name) || all_view_objects.size
         end
       end
 

--- a/spec/scenic/oracle_adapter_spec.rb
+++ b/spec/scenic/oracle_adapter_spec.rb
@@ -244,6 +244,18 @@ RSpec.describe Scenic::OracleAdapter do
       expect(views).to eq(%w[apples bananas kiwis watermelons])
     end
 
+    it "doesn't exclude dumped views if they're missing from tsorted views" do
+      allow(adapter).to receive(:all_view_objects).and_return([
+        Scenic::View.new(name: "a", definition: "", materialized: false),
+        Scenic::View.new(name: "b", definition: "", materialized: false),
+        Scenic::View.new(name: "c", definition: "", materialized: false)
+      ])
+
+      allow(adapter).to receive(:dependency_order).and_return(["c", "b"])
+
+      expect(adapter.views.map(&:name)).to eq(%w[c b a])
+    end
+
     # Demonstrates https://github.com/cdinger/scenic-oracle_adapter/issues/18
     it "excludes external dependencies" do
       adapter.create_materialized_view("depends_on_external_views", <<~EOS)

--- a/spec/scenic/oracle_adapter_spec.rb
+++ b/spec/scenic/oracle_adapter_spec.rb
@@ -280,6 +280,17 @@ RSpec.describe Scenic::OracleAdapter do
 
       expect { adapter.views }.to_not raise_error
     end
+
+    it "strips newlines and trailing semicolons from view definitions" do
+      adapter.create_view("a", <<~EOS)
+        select 1 as id
+        from dual
+        ;
+
+      EOS
+
+      expect(adapter.views.first.definition).to eq("select 1 as id\nfrom dual")
+    end
   end
 
   context "mocks" do


### PR DESCRIPTION
This provides a default fallback sorting if a view is missing from the increasingly complex `view_dependencies` query. We've already encountered several edge cases were views are missing or misclassified in Oracle's `user_dependencies` view.

If a new edge case pops up this should not explode on a failed index lookup. Instead it will be added to the end of the sorted views array.