### PR TITLE
Remove internal spaces with `trimmed_definition`

### DIFF
--- a/lib/scenic/adapters/oracle.rb
+++ b/lib/scenic/adapters/oracle.rb
@@ -138,7 +138,9 @@ module Scenic
       end
 
       def trimmed_definition(sql)
-        sql.strip.sub(/;$/, "").strip
+        sql.sub(/\s*;\s*$/, "")
+          .lines.map { |line| line.strip }
+          .join("\n")
       end
     end
   end


### PR DESCRIPTION
Fixes #23

Issue with the Old trimmed_definition Method:

The original implementation of the `trimmed_definition` method was designed to sanitize SQL definitions by removing unnecessary whitespace and trailing semicolons, it did the following:

  - `sql.strip`: Removed leading and trailing whitespace from the entire SQL string.
  - `.sub(/;$/, "")`: Eliminated a trailing semicolon if present.
  - `.strip`: Ensured any additional whitespace introduced after the substitution is removed.

While effective in trimming the outermost whitespace and trailing semicolons, the old method did not address internal indentation within multi-line SQL statements. Specifically:

  - **Line-Level Indentation Ignored:** Each line within the SQL definition could retain its own leading spaces or tabs. When these SQL definitions are embedded within Ruby heredocs (e.g., `<<-SQL`), the surrounding Ruby code's indentation inadvertently compounds the SQL's internal indentation.
  - **Cumulative Indentation Issue:** Every time `db:schema:dump` is executed, Rails preserves the existing indentation within the heredoc. Since the `trimmed_definition` method didn't normalize the indentation of each line, repeated schema dumps led to incremental increases in indentation, causing persistent and unwieldy diffs in version control.

Add two tests to ensure `trimmed_definition` behaves as expected:

  - The first spec Verifies that the leading whitespace is removed from all lines of a multi-line SQL statement.
  - The second test mimics the behavior seen with the capture of the db/schema.rb and the cumulative indenting that occurred when performing a schema load based on the schema.rb. It iterates over a view creation/update multiple times to stand in for schema dumps and reloading from the schema.rb file.

To resolve the indentation accumulation, the trimmed_definition method was enhanced to normalize the indentation of each individual line within the SQL definition. The updated method completes the following:

  1. Initial Stripping: - `.sub(/\s*;\s*$/, "")`: Continues to eliminate any trailing semicolon regardless of potential surrounding whitespace using the regular expression substitution.
  2. Line-by-Line Processing:
    - `.lines.map { |line| line.strip }`: Iterates over each line of the SQL definition, stripping leading and trailing whitespace from each individual line. This ensures that internal indentation within the SQL is removed, preventing it from being compounded by the surrounding Ruby code's indentation. It also handles the leading whitespace of the first line, if any which allows for removing the `.strip` before iterating through the lines.
  3. Reconstruction: - `.join("\n")`: Reassembles the cleaned lines back into a single SQL string with standardized line breaks, free from inconsistent internal indentation.

By implementing these changes:

  - **Consistent SQL Formatting:** Each SQL definition is embedded within `db/schema.rb` without additional leading spaces, regardless of the Ruby code's indentation level.
  - **Elimination of Cumulative Indentation:** Repeated schema dumps no longer introduce incremental indentation, resulting in stable and clean diffs in version control systems like Git.
  - **Improved Maintainability:** Developers can now manage and review schema changes without being distracted by unnecessary whitespace differences, enhancing overall productivity and code quality. Addresses the bug where `ActiveRecord::Migration.maintain_test_schema!` was quietly reloading the `db/schema.rb` since it detected a difference (whitespace only), thereby wiping the database seeds that some tests relied on for authentication.