### PR TITLE
Generate a consistent schema.rb file

### DIFF
--- a/lib/scenic/adapters/oracle.rb
+++ b/lib/scenic/adapters/oracle.rb
@@ -3,6 +3,8 @@
 require_relative "oracle/index_reapplication"
 require_relative "oracle/indexes"
 require_relative "oracle/refresh_dependencies"
+require_relative "oracle/view"
+require "active_support/core_ext/string/strip"
 require "tsortable_hash"
 
 module Scenic
@@ -119,13 +121,13 @@ module Scenic
 
       def all_views
         select_all("select lower(view_name) name, text definition from user_views").map do |view|
-          Scenic::View.new(name: view["name"], definition: view["definition"], materialized: false)
+          Scenic::Adapters::Oracle::View.new(name: view["name"], definition: view["definition"], materialized: false)
         end
       end
 
       def all_mviews
         select_all("select lower(mview_name) as name, query as definition from user_mviews").map do |view|
-          Scenic::View.new(name: view["name"], definition: view["definition"], materialized: true)
+          Scenic::Adapters::Oracle::View.new(name: view["name"], definition: view["definition"], materialized: true)
         end
       end
 
@@ -138,7 +140,7 @@ module Scenic
       end
 
       def trimmed_definition(sql)
-        sql.strip.sub(/;$/, "").strip
+        sql.rstrip.sub(/;$/, "").rstrip.strip_heredoc
       end
     end
   end

--- a/lib/scenic/adapters/oracle/view.rb
+++ b/lib/scenic/adapters/oracle/view.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/string/indent"
+
+module Scenic
+  module Adapters
+    class Oracle
+      class View < Scenic::View
+        def to_schema
+          materialized_option = materialized ? "materialized: true, " : ""
+
+          <<-DEFINITION
+  create_view #{UnaffixedName.for(name).inspect}, #{materialized_option}sql_definition: <<-\SQL
+#{escaped_definition.indent(6)}
+  SQL
+          DEFINITION
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,6 +62,14 @@ def wait_for_database_container
   end
 end
 
+def dump_schema(file_path)
+  dumper = ActiveRecord::Base.connection.create_schema_dumper({table_name_prefix: ActiveRecord::Base.table_name_prefix, table_name_suffix: ActiveRecord::Base.table_name_suffix})
+
+  File.open(file_path, "w:utf-8") do |file|
+    dumper.dump(file)
+  end
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"


### PR DESCRIPTION
**Problem**

When loading an existing schema that contains `create_view` statements and then dumping the schema (e.g., if a test script calls `db:migrate` before running tests), the `schema.rb` file changes even though the database objects remain the same. This inconsistency can also occur when tests use `ActiveRecord::Migration.maintain_test_schema!`. This issue may be related to or resolve #23.

**Example**

Suppose we start with a `schema.rb` that contains a Scenic view:
```
  create_view "my_view", sql_defintion: <<-SQL
      SELECT
        1 AS value
      FROM
        dual
  SQL
```

The `sql_definition`, is a multi-line string:
`"        SELECT\n        1 AS value\n      FROM\n        dual\n"`

When `schema:load` is executed, it creates the view using `trimmed_definition` which removes leading whitespace but preserves the indentation of subsequent lines. As a result, the view in Oracle is:
```
SELECT
        1 AS value
      FROM
        dual
```

After dumping the schema (e.g., after a migration), the view appears as:
```
  create_view "my_view", sql_definition: <<-SQL
      SELECT
          1 AS value
        FROM
          dual
  SQL
```
Notably:
  * The first line (`SELECT`) matches the original formatting.
  * Subsequent lines are indented two more spaces than before.

**Cause**

The issue arises from Scenic's `to_schema` method, which uses a heredoc as a template for the `create_view` statement and applies `indent(2)` to the view definition:
```
    def to_schema
      materialized_option = materialized ? "materialized: true, " : ""

      <<-DEFINITION
  create_view #{UnaffixedName.for(name).inspect}, #{materialized_option}sql_definition: <<-\SQL
    #{escaped_definition.indent(2)}
  SQL
      DEFINITION
    end
```

The `indent(2)` adds two leading spaces to each line of the view definition. While `trimmed_definition` removes leading spaces from the first line, it does not adjust the indentation of subsequent lines. This results in extra spaces accumulating in the `schema.rb` file each time the schema is loaded and dumped.

**Solution**

To fix this we:
  1. Updated `trimmed_definition`: We replaced `strip` with [`strip_heredoc`](https://api.rubyonrails.org/classes/String.html#method-i-strip_heredoc) and `rstrip` to remove a consistent amount of leading whitespace from all lines (if any) and trailing whitespace from the definition.
  2. Added a custom `View` Class: We introduced a `View` class to the Scenic Oracle adapter with a custom `to_schema` method. This addresses formatting issues caused by inconsistent indentation between the first line and the rest due to the `heredoc` and `indent(2)`.

**Testing**

We added a test to simulate this behavior. One implementation detail for this test is a helper method in `spec_helper` to dump the schema. This ensures we get a fresh dumper each time because the dumper seems to cache the database state from when it was initialized, so reusing it does not detect schema changes.