### PR TITLE
Add config to silence ActiveRecord output in tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -95,5 +95,12 @@ RSpec.configure do |config|
 
       ActiveRecord::Base.establish_connection("oracle-enhanced://scenic_oracle_adapter:scenic_oracle_adapter@db/orclpdb1")
     end
+
+    @active_record_verbosity = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+  end
+
+  config.after(:suite) do
+    ActiveRecord::Migration.verbose = @active_record_verbosity
   end
 end


### PR DESCRIPTION
Several tests have messages from ActiveRecord that inject into the RSpec test output. This removes those notifications to ensure clear test result output without the multi-line noise. Some of the messaging comes from #26 (parallel PR), others from #7.

When the test suite begins, the value of
`ActiveRecord::Migration.verbose` is captured and then set to `false`. After the suite is done running the initial value is reinstated.

Examples of messages silenced:
```
-- create_view("multi_newline_and_semicolon", {:sql_definition=>"      select\n        3 as fancy_c\n      from\n        dual\n"})
   -> 0.0015s
   -> 0 rows
-- create_view("multiline_internal_indented", {:sql_definition=>"      SELECT\n          1 AS fancy_a,\n          CASE\n              WHEN 1=1 THEN 'Y'\n              ELSE 'N'\n          END AS fancy_b\n      FROM\n          dual\n"})
   -> 0.0011s
   -> 0 rows
-- create_view("multiline_left_justified", {:sql_definition=>"      select\n      1 as a\n      from\n      dual\n"})
   -> 0.0010s
   -> 0 rows
.   -> index 'THINGS_ID' on 'THINGS' has been recreated
   -> index 'THINGS_NAME' on 'THINGS' has been recreated
.   -> index 'THINGS_ID' on 'THINGS' has been recreated
   -> index 'THINGS_NAME' on 'THINGS' is no longer valid and has been dropped.
```

Co-authored-by: Davin Lagerroos <dlagerro@umn.edu>
Co-authored-by: Eric Eklund <eeklund@umn.edu>