### PR TITLE
Truncate mviews before dropping

### DIFF
--- a/lib/scenic/adapters/oracle.rb
+++ b/lib/scenic/adapters/oracle.rb
@@ -47,6 +47,7 @@ module Scenic
       end
 
       def drop_materialized_view(name)
+        execute("truncate table #{quote_table_name(name)}")
         execute("drop materialized view #{quote_table_name(name)}")
       end
 


### PR DESCRIPTION
Doing a drop on a large table can be quite slow as Oracle stuffs the whole thing in to its undo log.

A truncate removes all records w/o possibility of undo. It's quite fast. And then the subsequent drop is also fast.